### PR TITLE
Add example of use ecmcEpicsEnvSetCalcTenary iocsh-command.

### DIFF
--- a/examples/test/iocshUtils/ecmcEpicsEnvSetCalcTenary.script
+++ b/examples/test/iocshUtils/ecmcEpicsEnvSetCalcTenary.script
@@ -1,0 +1,32 @@
+#
+# Test iocsh function "ecmcEpicsEnvSetCalcTenary()" to evaluate expressions and set 
+# EPCIS environment variables to differnt strings.
+#
+#        Use "ecmcEpicsEnvSetCalcTenary(<envVarName>,  <expression>, <trueString>, <falseString>)" to evaluate the expression and assign the variable.
+#          <envVarName>  : EPICS environment variable name.
+#          <expression>  : Calculation expression (see exprTK for available functionality). Examples:
+#                          Simple expression:"5.5+${TEST_SCALE}*sin(${TEST_ANGLE}/10)".
+#                          Use of "RESULT" variable: "if(${TEST_VAL}>5){RESULT:=100;}else{RESULT:=200;};".
+#          <trueString>  : String to set <envVarName> if expression (or "RESULT") evaluates to true.
+#          <falseString> : String to set <envVarName> if expression (or "RESULT") evaluates to false.
+#
+#
+require ecmc anders_dev20200228
+#
+# Help screens
+ecmcEpicsEnvSetCalcTenary -h
+ecmcEpicsEnvSetCalcTenary --help
+ecmcEpicsEnvSetCalcTenary
+#
+# Simple true false
+epicsEnvSet("VALUE",10)
+# ecmcEpicsEnvSetCalcTenary("test_var", "${VALUE}+2+5/10","True","False")
+ecmcEpicsEnvSetCalcTenary("test_var", "${VALUE}+2+5/10","True","False")
+epicsEnvShow("test_var")
+#
+# Can be used for choosing different files
+# ecmcEpicsEnvSetCalcTenary("filename", "${VALUE}>20","./plc_fast.cfg","./plc_slow.cfg")
+ecmcEpicsEnvSetCalcTenary("filename", "${VALUE}>20","./plc_fast.cfg","./plc_slow.cfg")
+epicsEnvShow("filename")
+#
+#


### PR DESCRIPTION
Command to set an environment variable to different strings depending on
if an expression/calcuation evaluates to true or false.