### PR TITLE
Fixed example in examples/test/plcWithoutEc/plc_axis_no_ec.script for…

### DIFF
--- a/examples/test/plcWithoutEc/cfg/linear_1.vax
+++ b/examples/test/plcWithoutEc/cfg/linear_1.vax
@@ -11,7 +11,7 @@ epicsEnvSet("ECMC_MOD_RANGE" ,            "0")                        # Modulo r
 epicsEnvSet("ECMC_MOD_TYPE",              "0")                        # For positioning and MOD_RANGE>0: 0 = Normal, 1 = Always Fwd, 2 = Always Bwd, 3 = Closest Distance
 
 #Encoder
-epicsEnvSet("ECMC_ENC_SCALE_NUM"          "0")
+epicsEnvSet("ECMC_ENC_SCALE_NUM"          "1")
 epicsEnvSet("ECMC_ENC_SCALE_DENOM"        "1")
 epicsEnvSet("ECMC_ENC_TYPE"               "1")                        # Type: 0=Incremental, 1=Absolute
 epicsEnvSet("ECMC_ENC_BITS"               "0")                        # Total bit count of encoder raw data

--- a/examples/test/plcWithoutEc/plc_axis_no_ec.script
+++ b/examples/test/plcWithoutEc/plc_axis_no_ec.script
@@ -8,10 +8,10 @@ epicsEnvSet("IOC" ,"$(IOC="IOC_TEST")")
 epicsEnvSet("ECMCCFG_INIT" ,"")  #Only run startup once (auto at PSI, need call at ESS), variable set to "#" in startup.cmd
 epicsEnvSet("SCRIPTEXEC" ,"$(SCRIPTEXEC="iocshLoad")")
 
-require ecmccfg 6.2.4
+require ecmccfg 6.3.2
 
 # run module startup.cmd (only needed at ESS  PSI auto call at require)
-$(ECMCCFG_INIT)$(SCRIPTEXEC) ${ecmccfg_DIR}startup.cmd, "IOC=$(IOC),ECMC_VER=6.2.4, MASTER_ID=-1"
+$(ECMCCFG_INIT)$(SCRIPTEXEC) ${ecmccfg_DIR}startup.cmd, "IOC=$(IOC),ECMC_VER=6.3.2, MASTER_ID=-1"
 
 ##############################################################################
 ## Configure hardware:


### PR DESCRIPTION
… version 6.3.0+

Starting in version 6.3.0, motion/ecmc_virt_axis.cmd checks that ECMC_ENC_SCALE_NUM is different than 0, so the example couldn't start properly.