### PR TITLE
Switched away from _TEMPLATES to _DB

### DIFF
--- a/startup.cmd
+++ b/startup.cmd
@@ -55,7 +55,7 @@ epicsEnvUnset(ECMC_EXE_CMD)
 #-------------------------------------------------------------------------------
 #- define default PATH for scripts and database/templates
 epicsEnvSet("ECMC_CONFIG_ROOT",     "${ecmccfg_DIR}")
-epicsEnvSet("ECMC_CONFIG_DB",       "${ecmccfg_TEMPLATES}/")
+epicsEnvSet("ECMC_CONFIG_DB",       "${ecmccfg_DB}")
 #- define command for script execution, PSI: <3.15 runScript(), else like for ESS: iocshLoad()
 epicsEnvSet("SCRIPTEXEC",           "${SCRIPTEXEC=iocshLoad}")
 #-


### PR DESCRIPTION
The variable _TEMPLATES is redundant, and should be replaced with _DB. Moreover, as of the latest version of require will add the trailing slash by default.

Note that this pull request is ESS-specific; if this does not belong here, then we can simply add this to the e3 wrapper.