### PR TITLE
Re-add missing status for analog terminals.

### DIFF
--- a/db/Beckhoff_3XXX/ecmcEL3002.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3002.substitutions
@@ -4,7 +4,7 @@ file "ecmc_analogInput-chX.template"{
           {02,    3.0518509476E-4,  "V",  3   }
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3004.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3004.substitutions
@@ -6,7 +6,7 @@ file "ecmc_analogInput-chX.template"{
           {04,    3.0518509476E-4,  "V",  3   }
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3104.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3104.substitutions
@@ -6,7 +6,7 @@ file "ecmc_analogInput-chX.template"{
           {04,    3.0518509476E-4,  "V",  3   }
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3154.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3154.substitutions
@@ -7,7 +7,7 @@ file "ecmc_analogInput-chX.template"{
           {04,    3.0518509476E-4,  "mA", 3   }
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3162.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3162.substitutions
@@ -4,7 +4,7 @@ file "ecmc_analogInput-chX.template"{
           {02,    3.0518509476E-4,  "V",  3   }
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3164.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3164.substitutions
@@ -6,7 +6,7 @@ file "ecmc_analogInput-chX.template"{
           {04,    3.0518509476E-4,  "V",  3   }
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3174.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3174.substitutions
@@ -8,7 +8,7 @@ file "ecmc_analogInput-chX.template"
           {04,    "Raw"}
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3174_+-10V.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3174_+-10V.substitutions
@@ -8,7 +8,7 @@ file "ecmc_analogInput-chX.template"
           {04,    3.2767723624E-4, 0,    "V", 3,    -10, -10.5, 10,   10.5, 0,    "MAJOR", "MINOR", "MINOR", "MAJOR"}
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3174_+-20mA.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3174_+-20mA.substitutions
@@ -8,7 +8,7 @@ file "ecmc_analogInput-chX.template"
           {04,    6.5535447249E-4, 0,    "mA", 3,    -20, -21,   20,  21,   0,    "MAJOR", "MINOR", "MINOR", "MAJOR"}
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3174_0to10V.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3174_0to10V.substitutions
@@ -8,7 +8,7 @@ file "ecmc_analogInput-chX.template"
           {04,    3.2767723624E-4, 0,    "V", 3,    0,   -1,   10,   10.5,  0,    "MAJOR", "MINOR", "MINOR", "MAJOR"}
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3174_0to20mA.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3174_0to20mA.substitutions
@@ -8,7 +8,7 @@ file "ecmc_analogInput-chX.template"
           {04,    6.5535447249E-4,  0,    "mA", 3,    0,   -1,   20,   21,   0,    "MAJOR", "MINOR", "MINOR", "MAJOR"}
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3174_4to20mA.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3174_4to20mA.substitutions
@@ -7,7 +7,7 @@ file "ecmc_analogInput-chX.template"{
           {04,    5.2428075234E-4, "mA", 4,    3   , 4,   3,    20,   21,   "MAJOR", "MAJOR", "MINOR", "MAJOR"}
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3202-0010.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3202-0010.substitutions
@@ -5,7 +5,7 @@ file "ecmc_analogInput-chX.template"
           {02,    0.01, 0,    "DegC", 3   }
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3204.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3204.substitutions
@@ -7,7 +7,7 @@ file "ecmc_analogInput-chX.template"
           {04,     0.1,  0,    "DegC", 2   }
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3208.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3208.substitutions
@@ -11,7 +11,7 @@ file "ecmc_analogInput-chX.template"
           {08,    0.1,  0,    "DegC", 2   }
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3214.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3214.substitutions
@@ -7,7 +7,7 @@ file "ecmc_analogInput-chX.template"
           {04,    0.1,    0,      "DegC", 2   }
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3255.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3255.substitutions
@@ -8,7 +8,7 @@ file "ecmc_analogInput-chX.template"
           {05,    3.0518509E-4, 0,    "V",  3   }
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3314.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3314.substitutions
@@ -7,7 +7,7 @@ file "ecmc_analogInput-chX.template"
           {04,    0.1,  0,    "DegC", 2   }
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEL3602.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEL3602.substitutions
@@ -5,7 +5,7 @@ file "ecmc_analogInput-chX.template"
           {02,    4.656612875E-9, 0,    "V", 3   }
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEM3702.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEM3702.substitutions
@@ -4,7 +4,7 @@ file "ecmc_analogInput-chX.template"{
           {02,    0.001, "bar",  3   }
 }
 
-file "ecmc_status-chX.template"
+file "ecmc_status_analog-chX.template"
 {
   pattern {CH_ID, KEY }
           {01,    "AI"}

--- a/db/Beckhoff_3XXX/ecmcEP3162.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEP3162.substitutions
@@ -6,7 +6,7 @@ file "ecmc_analogInput-chX.template"{
 }
 
 # channel status
-file "ecmc_status-chX.template"{
+file "ecmc_status_analog-chX.template"{
   pattern {CH_ID, KEY}
           {01,    AI }
           {02,    AI }

--- a/db/Beckhoff_3XXX/ecmcEP3204.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEP3204.substitutions
@@ -8,7 +8,7 @@ file "ecmc_analogInput-chX.template"{
 }
 
 # channel status
-file "ecmc_status-chX.template"{
+file "ecmc_status_analog-chX.template"{
   pattern {CH_ID, KEY}
           {01,    AI }
           {02,    AI }

--- a/db/Beckhoff_3XXX/ecmcEP3744.substitutions
+++ b/db/Beckhoff_3XXX/ecmcEP3744.substitutions
@@ -18,7 +18,7 @@ file "ecmc_analogInput-chX.template"{
 }
 
 # channel status
-file "ecmc_status-chX.template"{
+file "ecmc_status_analog-chX.template"{
   pattern {CH_ID, KEY}
           {01,    "AI" }
           {02,    "AI" }

--- a/db/generic/ecmc_status_analog-chX.template
+++ b/db/generic/ecmc_status_analog-chX.template
@@ -1,3 +1,12 @@
+#- statusword template
+#- MACROS
+#- mandatory
+#-  ECMC_P
+#-  KEY
+#-  CH_ID
+#- optional
+#-  sourceName, defaults to 'status'
+
 record(mbbiDirect,"${ECMC_P}${KEY=AI}${CH_ID}-Stat"){
   field(DESC, "$(HWTYPE): AI$(CH_ID): Status Word")
   field(PINI, "$(PINI=1)")
@@ -39,3 +48,4 @@ record(bi,"${ECMC_P}${KEY=AI}${CH_ID}-ErrAlrm"){
   field(OSV,  "MAJOR")
   field(TSE,  "$(TSE=-2)")
 }
+


### PR DESCRIPTION
Seems status alarms for analog terminals disappeared in v7. Re added.